### PR TITLE
joblib version change to fix pyinstaller on *nix

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -6,7 +6,7 @@ Flask==1.1.1
 isort==4.3.21
 itsdangerous==1.1.0
 Jinja2==2.10.1
-joblib==0.13.2
+joblib==0.11
 jsonpickle==1.2
 jsonschema==3.0.1
 lazy-object-proxy==1.4.1


### PR DESCRIPTION
Apparently the pyinstaller issues we have been experiencing on macOS are related to some issue with joblib, a dependency of sklearn. The fix is simple and discussed here: https://github.com/pyinstaller/pyinstaller/issues/4110